### PR TITLE
Remove Hot Column from index.html.erb

### DIFF
--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -22,7 +22,6 @@
                 <th>Last Name</th>
                 <th>Email</th>
                 <th>Phone</th>
-                <th>Hot?</th>
                 <th>Appointment Date</th>
                 
               </tr>
@@ -34,7 +33,6 @@
                 <td>{{ lead.last_name }}</td>
                 <td><a v-bind:href="'/leads/' + lead.id + '/edit'">{{ lead.email }}</a></td>
                 <td>{{ lead.phone }}</td>
-                <td>{{ lead.hot }}</td>
                 <td>{{ moment(lead.appointment_date).format('dddd MMM Do YYYY, h:mm a') }}</td>
 
               </tr>


### PR DESCRIPTION
https://trello.com/c/jowLNrKB/12-148-remove-the-hot-column-from-the-leads-index-page

***background***
Employer asked to remove "Hot?" column.

***objective***
We wanted to remove both the column header and column contents. We did this by removing two lines from the index.html.erb file. 